### PR TITLE
use correct block for getting totalSupply and price

### DIFF
--- a/scripts/rewards/rewards-generator.js
+++ b/scripts/rewards/rewards-generator.js
@@ -117,11 +117,18 @@ async function main(
   }
 
   while (!finalized) {
-    const [totalSupply, price] = await tryGetMulticallResults(
+    const [price] = await tryGetMulticallResults(
       multicall,
-      [nftContract.vaultCount(), vaultContract.getEthPriceSource()],
+      [vaultContract.getEthPriceSource()],
       true,
       blockNumber
+    );
+
+    const [totalSupply] = await tryGetMulticallResults(
+      multicall,
+      [nftContract.vaultCount()],
+      true,
+      endBlock
     );
 
     const nVaults = parseInt(totalSupply.toString());

--- a/scripts/rewards/rewards-generator.js
+++ b/scripts/rewards/rewards-generator.js
@@ -121,7 +121,7 @@ async function main(
       multicall,
       [nftContract.vaultCount(), vaultContract.getEthPriceSource()],
       true,
-      endBlock
+      blockNumber
     );
 
     const nVaults = parseInt(totalSupply.toString());


### PR DESCRIPTION
just looks like a simple bug that slipped in - the script was getting the price of the collateral at the `endBlock` instead of the current block that is being calculated - this is obviously incorrect as it leads to an incorrect CDR and some vaults not being eligible for rewards when they should be. (and maybe vice-versa, too.)

lmk if you have questions :)